### PR TITLE
Fix version info len

### DIFF
--- a/Aptabase.Client.sln
+++ b/Aptabase.Client.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kingas.Aptabase.Client", "Kingas.Aptabase.Client\Kingas.Aptabase.Client.csproj", "{AF96A032-7FA2-422F-ABB2-83AEC86B4722}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kingas.Aptabase.Client", "Kingas.Aptabase.Client\Kingas.Aptabase.Client.csproj", "{AF96A032-7FA2-422F-ABB2-83AEC86B4722}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kingas.Aptabase.Client.Tests", "Kingas.Aptabase.Client.Tests\Kingas.Aptabase.Client.Tests.csproj", "{29EA08CE-9A6D-4A72-8719-7E8E6A3F11DA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{AF96A032-7FA2-422F-ABB2-83AEC86B4722}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF96A032-7FA2-422F-ABB2-83AEC86B4722}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF96A032-7FA2-422F-ABB2-83AEC86B4722}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29EA08CE-9A6D-4A72-8719-7E8E6A3F11DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29EA08CE-9A6D-4A72-8719-7E8E6A3F11DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29EA08CE-9A6D-4A72-8719-7E8E6A3F11DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29EA08CE-9A6D-4A72-8719-7E8E6A3F11DA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Kingas.Aptabase.Client.Tests/GlobalUsings.cs
+++ b/Kingas.Aptabase.Client.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Kingas.Aptabase.Client.Tests/Kingas.Aptabase.Client.Tests.csproj
+++ b/Kingas.Aptabase.Client.Tests/Kingas.Aptabase.Client.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kingas.Aptabase.Client\Kingas.Aptabase.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Kingas.Aptabase.Client.Tests/UnitTest1.cs
+++ b/Kingas.Aptabase.Client.Tests/UnitTest1.cs
@@ -1,0 +1,15 @@
+using Aptabase;
+
+namespace Kingas.Aptabase.Client.Tests
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+            var client = new AptabaseClient("T-DEV-Test", null, null);
+            client.TrackEvent("test");
+            Thread.Sleep(5000);
+        }
+    }
+}

--- a/Kingas.Aptabase.Client/Kingas.Aptabase.Client.csproj
+++ b/Kingas.Aptabase.Client/Kingas.Aptabase.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>Kingas.Aptabase</PackageId>
-    <Version>0.0.1</Version>
+    <Version>0.2</Version>
     <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
 		<Description>.NET Client for Aptabase: Open Source, Privacy-First and Simple Analytics for .NET</Description>
 		<Authors>Pavel Tsimokhautsau</Authors>

--- a/Kingas.Aptabase.Client/SystemInfo.cs
+++ b/Kingas.Aptabase.Client/SystemInfo.cs
@@ -21,8 +21,8 @@ internal class SystemInfo
 	{
         this.IsDebug = IsInDebugMode(assembly);
         this.OsName = GetOsName();
-        this.OsVersion = Clamp(GetOsVersion(), 30);
-        this.SdkVersion = Clamp(GetSdkVersion(), 40);
+        this.OsVersion = GetOsVersion();
+        this.SdkVersion = GetSdkVersion();
         this.Locale = Thread.CurrentThread.CurrentCulture.Name;
         var appVersion = Assembly.GetEntryAssembly()?.GetName().Version;
         this.AppVersion = appVersion?.ToString() ?? string.Empty;
@@ -71,13 +71,5 @@ internal class SystemInfo
         var sdkVersion = _pkgVersion?.Version ?? "UNKNOWN";
         var sdkName = "Kingas.Aptabase";
         return $"{sdkName}@{sdkVersion}";
-    }
-
-    private string Clamp(string value, int length)
-    {
-        if (value.Length > length)
-            return value.Substring(0, length);
-        
-        return value;
     }
 }

--- a/Kingas.Aptabase.Client/SystemInfo.cs
+++ b/Kingas.Aptabase.Client/SystemInfo.cs
@@ -6,8 +6,8 @@ namespace Aptabase;
 
 internal class SystemInfo
 {
-    private static string _pkgVersion = typeof(AptabaseClient).Assembly
-        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
+    private static readonly AssemblyFileVersionAttribute? _pkgVersion =
+        typeof(AptabaseClient).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
 
     public bool IsDebug { get; }
     public string OsName { get; }
@@ -21,14 +21,14 @@ internal class SystemInfo
 	{
         this.IsDebug = IsInDebugMode(assembly);
         this.OsName = GetOsName();
-        this.OsVersion = GetOsVersion();
-        this.SdkVersion = $"Kingas.Aptabase@{_pkgVersion}";
+        this.OsVersion = Clamp(GetOsVersion(), 30);
+        this.SdkVersion = Clamp(GetSdkVersion(), 40);
         this.Locale = Thread.CurrentThread.CurrentCulture.Name;
         var appVersion = Assembly.GetEntryAssembly()?.GetName().Version;
         this.AppVersion = appVersion?.ToString() ?? string.Empty;
         this.AppBuildNumber = (appVersion?.Build ?? 0).ToString();
     }
-        
+
     private static bool IsInDebugMode(Assembly? assembly)
     {
         if (assembly == null)
@@ -63,7 +63,21 @@ internal class SystemInfo
 
     private string GetOsVersion()
     {
-        return Environment.OSVersion.VersionString;
+        return Environment.OSVersion.Version.ToString();
+    }
+
+    private string GetSdkVersion()
+    {
+        var sdkVersion = _pkgVersion?.Version ?? "UNKNOWN";
+        var sdkName = "Kingas.Aptabase";
+        return $"{sdkName}@{sdkVersion}";
+    }
+
+    private string Clamp(string value, int length)
+    {
+        if (value.Length > length)
+            return value.Substring(0, length);
+        
+        return value;
     }
 }
-


### PR DESCRIPTION
# Reason

The field OSVersion must be a string with a maximum length of 30.
The field SdkVersion must be a string with a maximum length of 40.

# Changes

- Use `OSVersion.Version`
- Use `AssemblyFileVersionAttribute` for package version
